### PR TITLE
Enable live trading via Alpaca

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,10 @@ FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 # For running LLMs hosted by openai (gpt-4o, gpt-4o-mini, etc.)
 # Get your OpenAI API key from https://platform.openai.com/
 OPENAI_API_KEY=your-openai-api-key
+
+# For sending trades to Alpaca
+# Sign up at https://alpaca.markets/ and get your API keys
+ALPACA_API_KEY=your-alpaca-api-key
+ALPACA_SECRET_KEY=your-alpaca-secret-key
+# Use https://paper-api.alpaca.markets for paper trading or https://api.alpaca.markets for live
+ALPACA_BASE_URL=https://paper-api.alpaca.markets

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ This system employs several agents working together:
 <img width="1042" alt="Screenshot 2025-03-22 at 6 19 07 PM" src="https://github.com/user-attachments/assets/cbae3dcf-b571-490d-b0ad-3f0f035ac0d4" />
 
 
-**Note**: the system simulates trading decisions, it does not actually trade.
+**Note**: by default the system only simulates trading decisions. If you set your
+Alpaca API keys, the resulting orders will be sent automatically to your
+brokerage account.
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/virattt?style=social)](https://twitter.com/virattt)
 
@@ -62,6 +64,9 @@ git clone https://github.com/virattt/ai-hedge-fund.git
 cd ai-hedge-fund
 ```
 
+You can run `./setup.sh` for a one-step install of dependencies and creation of
+the `.env` file, then edit it with your API keys.
+
 1. Install Poetry (if not already installed):
 ```bash
 curl -sSL https://install.python-poetry.org | python3 -
@@ -91,6 +96,12 @@ GROQ_API_KEY=your-groq-api-key
 # For getting financial data to power the hedge fund
 # Get your Financial Datasets API key from https://financialdatasets.ai/
 FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
+
+# For sending trades to Alpaca (paper or live)
+ALPACA_API_KEY=your-alpaca-api-key
+ALPACA_SECRET_KEY=your-alpaca-secret-key
+# Use https://paper-api.alpaca.markets for paper trading or https://api.alpaca.markets for live
+ALPACA_BASE_URL=https://paper-api.alpaca.markets
 ```
 
 ### Using Docker
@@ -156,6 +167,9 @@ run.bat --ticker AAPL,MSFT,NVDA main
 
 **Example Output:**
 <img width="992" alt="Screenshot 2025-01-06 at 5 50 17 PM" src="https://github.com/user-attachments/assets/e8ca04bf-9989-4a7d-a8b4-34e04666663b" />
+
+If the Alpaca environment variables are configured, these commands will also
+send the generated orders to your brokerage account.
 
 You can also specify a `--ollama` flag to run the AI hedge fund using local LLMs.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ tabulate = "^0.9.0"
 colorama = "^0.4.6"
 questionary = "^2.1.0"
 rich = "^13.9.4"
+requests = "^2.31.0"
 langchain-google-genai = "^2.0.11"
 # Backend dependencies
 fastapi = {extras = ["standard"], version = "^0.104.0"}

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+poetry install
+cp .env.example .env
+cat <<MSG
+Dependencies installed. Edit .env with your API keys (OPENAI_API_KEY, FINANCIAL_DATASETS_API_KEY, ALPACA_API_KEY, etc.)
+Then run: poetry run python src/main.py --ticker AAPL
+MSG

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from src.agents.portfolio_manager import portfolio_management_agent
 from src.agents.risk_manager import risk_management_agent
 from src.graph.state import AgentState
 from src.utils.display import print_trading_output
+from src.utils.alpaca import submit_orders
 from src.utils.analysts import ANALYST_ORDER, get_analyst_nodes
 from src.utils.progress import progress
 from src.llm.models import LLM_ORDER, OLLAMA_LLM_ORDER, get_model_info, ModelProvider
@@ -319,3 +320,4 @@ if __name__ == "__main__":
         model_provider=model_provider,
     )
     print_trading_output(result)
+    submit_orders(result.get("decisions", {}))

--- a/src/utils/alpaca.py
+++ b/src/utils/alpaca.py
@@ -1,0 +1,48 @@
+import os
+import requests
+
+
+def submit_orders(decisions: dict[str, dict]) -> None:
+    """Send trade orders to Alpaca based on portfolio manager decisions."""
+    api_key = os.getenv("ALPACA_API_KEY")
+    secret_key = os.getenv("ALPACA_SECRET_KEY")
+    base_url = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+
+    if not api_key or not secret_key:
+        print("Alpaca API keys not configured. Skipping order submission.")
+        return
+
+    headers = {
+        "APCA-API-KEY-ID": api_key,
+        "APCA-API-SECRET-KEY": secret_key,
+        "Content-Type": "application/json",
+    }
+
+    action_map = {
+        "buy": "buy",
+        "sell": "sell",
+        "short": "sell",
+        "cover": "buy",
+    }
+
+    for symbol, decision in decisions.items():
+        action = decision.get("action", "").lower()
+        qty = int(decision.get("quantity", 0))
+        if action == "hold" or qty <= 0:
+            continue
+        side = action_map.get(action)
+        order = {
+            "symbol": symbol,
+            "qty": qty,
+            "side": side,
+            "type": "market",
+            "time_in_force": "day",
+        }
+        try:
+            resp = requests.post(f"{base_url}/v2/orders", json=order, headers=headers)
+            if resp.status_code not in (200, 201):
+                print(f"Failed to submit order for {symbol}: {resp.text}")
+            else:
+                print(f"Submitted {side} order for {qty} {symbol}")
+        except Exception as e:
+            print(f"Error submitting order for {symbol}: {e}")


### PR DESCRIPTION
## Summary
- add Alpaca credentials to `.env.example`
- mention automatic order placement in README
- provide setup helper script
- include `requests` in dependencies
- add Alpaca order helper
- call helper from main

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685eb4cce6008327bb6f46cdf9e259f4